### PR TITLE
Replace start learning by se lancer

### DIFF
--- a/lang/fr/panel.php
+++ b/lang/fr/panel.php
@@ -48,7 +48,7 @@ return [
     'not_conducted' => 'Non réalisé',
 
     'upcoming' => 'À venir',
-    'start_learning' => 'Commencer à apprendre',
+    'start_learning' => 'Se lancer',
     'my_purchases_no_result' => 'Pas de cours acheté !',
     'my_purchases_no_result_hint' => 'Commencez à apprendre auprès des meilleurs formateurs et profitez-en...',
 

--- a/resources/views/web/default/includes/navbar.blade.php
+++ b/resources/views/web/default/includes/navbar.blade.php
@@ -112,11 +112,11 @@
 
                 @if(!empty($navBtnUrl))
                     <a href="{{ $navBtnUrl }}" class="d-none d-lg-flex btn btn-sm btn-primary nav-start-a-live-btn">
-                        {{ $navBtnText }}
+                    {{ trans('panel.start_learning') }}
                     </a>
 
                     <a href="{{ $navBtnUrl }}" class="d-flex d-lg-none text-primary nav-start-a-live-btn font-14">
-                        {{ $navBtnText }}
+                    {{ trans('panel.start_learning') }}
                     </a>
                 @endif
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the French translation for "Start Learning" to "Se lancer".
  - Navigation button now consistently displays the updated translation across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->